### PR TITLE
Avoiding interaction onFling if content view contains a ViewPager

### DIFF
--- a/ActionsContentViewLib/src/shared/ui/actionscontentview/ActionsContentView.java
+++ b/ActionsContentViewLib/src/shared/ui/actionscontentview/ActionsContentView.java
@@ -964,6 +964,10 @@ public class ActionsContentView extends ViewGroup {
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX,
         float velocityY) {
 
+      if (!mHandleEvent) {
+        return false;
+      }
+      
       final float absVelocityX = Math.abs(velocityX);
       if (absVelocityX <= Math.abs(velocityY))
         return false;


### PR DESCRIPTION
If content view contains a view with horizontal scroll, swiping it is intercepted by ActionsContentView onFling method.

This patch prevents this behaviour.
